### PR TITLE
fix: campfire loc_txt showing for vanilla campfire

### DIFF
--- a/jokers/campfire.lua
+++ b/jokers/campfire.lua
@@ -55,6 +55,8 @@ return {
 
     -- localization
     loc_vars = function(self, info_queue, card)
-        return { vars = { card.ability.extra.x_mult_mod, card.ability.extra.x_mult } }
+        return { 
+            key = self.key..'_alt',
+            vars = { card.ability.extra.x_mult_mod, card.ability.extra.x_mult } }
     end,
 }

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -11,7 +11,7 @@ return {
     },
     descriptions = {
         Joker = {
-            j_folly_campfire = {
+            j_folly_campfire_alt = {
                 name = "Campfire",
                 text = {
                     "This Joker gains {X:mult,C:white}X#1#{} Mult for",


### PR DESCRIPTION
replaces #7 

for now we should add a key to loc_vars and use that in localization file