### PR TITLE
Use stylua via npm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,5 @@ jobs:
       - uses: JohnnyMorganz/stylua-action@v4.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: latest
+          version: 2.1.0
           args: --check .
-                      
-            
-                        

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ﻿.idea
 Folder.DotSettings.user
+node_modules

--- a/jokers/astronomer.lua
+++ b/jokers/astronomer.lua
@@ -2,13 +2,13 @@ return {
     key = "astronomer",
     config = {
         extra = {
-            astro = nil
+            astro = nil,
         },
     },
     set_ability = function(self, card, initial, delay_sprites)
-        local pool, pool_key = get_current_pool('Planet')
+        local pool, pool_key = get_current_pool("Planet")
         for i = #pool, 1, -1 do
-            if pool[i] == 'UNAVAILABLE' then
+            if pool[i] == "UNAVAILABLE" then
                 table.remove(pool, i)
             end
         end

--- a/jokers/blueprint.lua
+++ b/jokers/blueprint.lua
@@ -12,7 +12,10 @@ SMODS.Joker({
             local temp_ID = math.huge
             local raised_card = nil
             for i = 1, #G.hand.cards do
-                if temp_ID >= G.hand.cards[i].base.id and G.hand.cards[i].ability.effect ~= 'Stone Card' then
+                if
+                    temp_ID >= G.hand.cards[i].base.id
+                    and G.hand.cards[i].ability.effect ~= "Stone Card"
+                then
                     temp_ID = G.hand.cards[i].base.id
                     raised_card = G.hand.cards[i]
                 end
@@ -20,7 +23,7 @@ SMODS.Joker({
             if raised_card == context.other_card then
                 if context.other_card.debuff then
                     return {
-                        message = localize('k_debuffed'),
+                        message = localize("k_debuffed"),
                         colour = G.C.RED,
                     }
                 else
@@ -62,7 +65,7 @@ SMODS.Joker({
             context.other_card.ability.perma_mult = (context.other_card.ability.perma_mult or 0) + 1
 
             return {
-                extra = { message = localize('k_upgrade_ex'), colour = G.C.MULT },
+                extra = { message = localize("k_upgrade_ex"), colour = G.C.MULT },
                 colour = G.C.MULT,
             }
         end
@@ -82,7 +85,7 @@ SMODS.Joker({
         extra = {
             xmult_mod = 0.02,
             xmult = 1,
-        }
+        },
     },
     in_pool = function(self, args)
         return false
@@ -91,15 +94,16 @@ SMODS.Joker({
         if context.final_scoring_step and not context.blueprint then
             for k, v in ipairs(context.scoring_hand) do
                 if v.base.nominal ~= 2 then
-                    card.ability.extra.xmult = card.ability.extra.xmult + card.ability.extra.xmult_mod
+                    card.ability.extra.xmult = card.ability.extra.xmult
+                        + card.ability.extra.xmult_mod
                     G.E_MANAGER:add_event(Event({
-                        trigger = 'after',
+                        trigger = "after",
                         delay = 0.1,
                         func = function()
                             SMODS.modify_rank(v, -1)
                             v:juice_up()
                             return true
-                        end
+                        end,
                     }))
                 end
             end
@@ -107,43 +111,54 @@ SMODS.Joker({
             return {
                 message = localize("k_folly_mansion"),
                 colour = G.C.RED,
-                card = card
+                card = card,
             }
         end
 
         if context.joker_main and card.ability.extra.xmult ~= 1 then
             return {
-                xmult = card.ability.extra.xmult
+                xmult = card.ability.extra.xmult,
             }
         end
     end,
 
     -- localization
     loc_vars = function(self, info_queue, card)
-        return { vars = {
-            card.ability.extra.xmult_mod,
-            card.ability.extra.xmult,
-        } }
+        return {
+            vars = {
+                card.ability.extra.xmult_mod,
+                card.ability.extra.xmult,
+            },
+        }
     end,
 })
 
-SMODS.DrawStep {
-    key = 'folly_debuff',
+SMODS.DrawStep({
+    key = "folly_debuff",
     order = 70,
     func = function(self)
         if self.folly_debuff then
-            self.children.center:draw_shader('debuff', nil, self.ARGS.send_to_shader)
-            if self.children.front and (self.ability.delayed or (self.ability.effect ~= 'Stone Card' and not self.config.center.replace_base_card)) then
-                self.children.front:draw_shader('debuff', nil, self.ARGS.send_to_shader)
+            self.children.center:draw_shader("debuff", nil, self.ARGS.send_to_shader)
+            if
+                self.children.front
+                and (
+                    self.ability.delayed
+                    or (
+                        self.ability.effect ~= "Stone Card"
+                        and not self.config.center.replace_base_card
+                    )
+                )
+            then
+                self.children.front:draw_shader("debuff", nil, self.ARGS.send_to_shader)
             end
         end
     end,
-    conditions = { vortex = false, facing = 'front' },
-}
+    conditions = { vortex = false, facing = "front" },
+})
 
 SMODS.Sound({
     key = "house_bach",
-    path = "house_bach.ogg"
+    path = "house_bach.ogg",
 })
 
 local mod_prefix = SMODS.current_mod.prefix
@@ -155,8 +170,8 @@ SMODS.Joker({
     config = {
         extra = {
             xmult = 2,
-            redebuff = {}
-        }
+            redebuff = {},
+        },
     },
     in_pool = function(self, args)
         return false
@@ -222,7 +237,7 @@ SMODS.Joker({
             if context.other_joker.debuff then
                 if context.blueprint then
                     return {
-                        xmult = card.ability.extra.xmult
+                        xmult = card.ability.extra.xmult,
                     }
                 end
                 local ret = context.other_joker:calculate_joker({
@@ -231,7 +246,8 @@ SMODS.Joker({
                     scoring_hand = context.scoring_hand,
                     scoring_name = context.scoring_name,
                     poker_hands = context.poker_hands,
-                    joker_main = true });
+                    joker_main = true,
+                })
                 card:juice_up()
                 ret.x_mult_mod = card.ability.extra.xmult
                 ret.message_card = context.other_joker
@@ -273,5 +289,5 @@ return {
                 folly_utils.replace(card, folly_utils.prefix.joker .. suffix)
             end
         end
-    end
+    end,
 }

--- a/jokers/burnt.lua
+++ b/jokers/burnt.lua
@@ -15,20 +15,20 @@ SMODS.Enhancement({
         if context.main_scoring and context.cardarea == G.play then
             self.burn = self.burn + card.ability.extra.base_gain
             return {
-                mult = self.burn
+                mult = self.burn,
             }
         end
     end,
     loc_vars = function(self, info_queue, card)
         return { vars = {
             card.ability.extra.base_gain,
-        }, }
+        } }
     end,
 })
 
 SMODS.Sound({
     key = "it_burns",
-    path = "it_burns.ogg"
+    path = "it_burns.ogg",
 })
 
 local mod_prefix = SMODS.current_mod.prefix
@@ -37,7 +37,10 @@ return {
     calculate = function(self, card, context)
         if context.discard and context.other_card then
             local other_card = context.other_card
-            if other_card.config.center ~= G.P_CENTERS.m_folly_burnt and pseudorandom(self.key) < G.GAME.probabilities.normal / 20 then
+            if
+                other_card.config.center ~= G.P_CENTERS.m_folly_burnt
+                and pseudorandom(self.key) < G.GAME.probabilities.normal / 20
+            then
                 other_card:set_ability(G.P_CENTERS.m_folly_burnt, nil, true)
                 G.E_MANAGER:add_event(Event({
                     delay = 1,
@@ -46,9 +49,9 @@ return {
                         play_sound(mod_prefix .. "_it_burns")
                         other_card:juice_up()
                         return true
-                    end
+                    end,
                 }))
             end
         end
-    end
+    end,
 }

--- a/jokers/campfire.lua
+++ b/jokers/campfire.lua
@@ -7,11 +7,15 @@ SMODS.Joker({
         extra_value = -6,
     },
     cost = 1,
-    in_pool = function(self, args) return false end,
+    in_pool = function(self, args)
+        return false
+    end,
     calculate = function(self, card, context)
-        if context.joker_main then return {
-            mult = -5,
-        } end
+        if context.joker_main then
+            return {
+                mult = -5,
+            }
+        end
     end,
 
     -- localization
@@ -35,13 +39,23 @@ return {
         if context.selling_card and not context.blueprint then -- selling adds fuel to the fire
             card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.x_mult_mod
             G.E_MANAGER:add_event(Event({
-                func = function() card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_upgrade_ex')}); return true
-                end}))
+                func = function()
+                    card_eval_status_text(
+                        card,
+                        "extra",
+                        nil,
+                        nil,
+                        nil,
+                        { message = localize("k_upgrade_ex") }
+                    )
+                    return true
+                end,
+            }))
         end
         if context.after then -- reduce xMult when a hand is scored
             card.ability.extra.x_mult = card.ability.extra.x_mult - card.ability.extra.x_mult_mod
             if card.ability.extra.x_mult <= 0 then
-                folly_utils.replace(card, folly_utils.prefix.joker.."charcoal") -- get charcoaled idiot
+                folly_utils.replace(card, folly_utils.prefix.joker .. "charcoal") -- get charcoaled idiot
             end
         end
         if context.joker_main then
@@ -55,8 +69,9 @@ return {
 
     -- localization
     loc_vars = function(self, info_queue, card)
-        return { 
-            key = self.key..'_alt',
-            vars = { card.ability.extra.x_mult_mod, card.ability.extra.x_mult } }
+        return {
+            key = self.key .. "_alt",
+            vars = { card.ability.extra.x_mult_mod, card.ability.extra.x_mult },
+        }
     end,
 }

--- a/jokers/cartomancer.lua
+++ b/jokers/cartomancer.lua
@@ -8,7 +8,8 @@ return {
             context.setting_blind
             and not context.blueprint
             and not card.getting_sliced
-            and #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit
+            and #G.consumeables.cards + G.GAME.consumeable_buffer
+                < G.consumeables.config.card_limit
         then
             G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
             return {

--- a/jokers/cavendish.lua
+++ b/jokers/cavendish.lua
@@ -10,13 +10,24 @@ return {
         name = "fj_cavendish",
     },
     loc_vars = function(self, info_queue, card)
-        return { vars = { card.ability.extra.Xmult, G.GAME.probabilities.normal, card.ability.extra.odds } }
+        return {
+            vars = {
+                card.ability.extra.Xmult,
+                G.GAME.probabilities.normal,
+                card.ability.extra.odds,
+            },
+        }
     end,
     calculate = function(self, card, context)
-        if context.end_of_round and not context.individual and not context.repetition and not context.blueprint then
-            if pseudorandom(self.key) >= G.GAME.probabilities.normal/card.ability.extra.odds then
-                card.ability.extra.odds = card.ability.extra.odds - card.ability.extra.rot;
-                card.ability.extra.rot = card.ability.extra.rot * 2;
+        if
+            context.end_of_round
+            and not context.individual
+            and not context.repetition
+            and not context.blueprint
+        then
+            if pseudorandom(self.key) >= G.GAME.probabilities.normal / card.ability.extra.odds then
+                card.ability.extra.odds = card.ability.extra.odds - card.ability.extra.rot
+                card.ability.extra.rot = card.ability.extra.rot * 2
                 card.ability.extra.odds = math.max(card.ability.extra.odds, 6)
                 return { message = localize("k_safe_ex") }
             else

--- a/jokers/drivers_license.lua
+++ b/jokers/drivers_license.lua
@@ -4,7 +4,9 @@ return {
     pos = { x = 0, y = 0 },
     calculate = function(self, card, context)
         if context.joker_main and (card.ability.driver_tally or 0) >= 16 then
-            if not context.blueprint then card.ability.driver_used = true end
+            if not context.blueprint then
+                card.ability.driver_used = true
+            end
             return {
                 xmult = card.ability.extra,
             }
@@ -52,7 +54,10 @@ return {
             trigger = "after",
             delay = 0.1,
             func = function()
-                SMODS.calculate_effect({ message = localize("k_folly_drivers_license_renewed") }, card)
+                SMODS.calculate_effect(
+                    { message = localize("k_folly_drivers_license_renewed") },
+                    card
+                )
                 SMODS.debuff_card(card, false, "drivers_license_expired")
                 card.ability.drivers_license_renewed = true
                 card.ability.folly_show_button = false
@@ -60,7 +65,9 @@ return {
 
                 play_sound("card1")
                 inc_career_stat("c_shop_dollars_spent", card.cost)
-                if card.cost ~= 0 then ease_dollars(-card.cost) end
+                if card.cost ~= 0 then
+                    ease_dollars(-card.cost)
+                end
 
                 card.area:remove_from_highlighted(card)
                 G.CONTROLLER.locks.selling_card = nil

--- a/jokers/greedy_joker.lua
+++ b/jokers/greedy_joker.lua
@@ -4,7 +4,9 @@ return {
         if context.end_of_round and not context.individual and not context.repetition then
             return {
                 message = localize("k_folly_greed"),
-                func = function() ease_dollars(-1) end,
+                func = function()
+                    ease_dollars(-1)
+                end,
             }
         end
     end,

--- a/jokers/gros_michel.lua
+++ b/jokers/gros_michel.lua
@@ -1,7 +1,12 @@
 return {
     key = "gros_michel",
     calculate = function(self, card, context)
-        if context.end_of_round and not context.individual and not context.repetition and not context.blueprint then
+        if
+            context.end_of_round
+            and not context.individual
+            and not context.repetition
+            and not context.blueprint
+        then
             if #G.jokers.cards > 1 then
                 return { message = localize("k_safe_ex") }
             else

--- a/jokers/joker.lua
+++ b/jokers/joker.lua
@@ -16,7 +16,7 @@ G.FUNCS.get_most_of_rank = function(hand)
         vals[i] = {}
     end
     for i = #hand, 1, -1 do
-        if not SMODS.has_enhancement(hand[i], 'm_folly_jimbo') then
+        if not SMODS.has_enhancement(hand[i], "m_folly_jimbo") then
             table.insert(vals[hand[i]:get_id()], hand[i])
         end
     end
@@ -34,7 +34,7 @@ G.FUNCS.get_most_of_rank = function(hand)
             end
         end
     end
-    
+
     local highest = 0
     if next(most_table) then
         for _, v in pairs(most_table) do
@@ -54,8 +54,9 @@ return {
     add_to_deck = function(self, card, from_debuff)
         if not from_debuff then
             local created_card = create_playing_card({
-                front = pseudorandom_element(G.P_CARDS, pseudoseed('jimbo_fr_fr')),
-                center = G.P_CENTERS.c_base}, G.deck, nil, nil, nil, nil)
+                front = pseudorandom_element(G.P_CARDS, pseudoseed("jimbo_fr_fr")),
+                center = G.P_CENTERS.c_base,
+            }, G.deck, nil, nil, nil, nil)
             created_card:set_ability(G.P_CENTERS.m_folly_jimbo, nil, true)
             play_sound("tarot1")
         end

--- a/jokers/marble.lua
+++ b/jokers/marble.lua
@@ -7,6 +7,8 @@ local mod_prefix = SMODS.current_mod.prefix
 return {
     key = "marble",
     calculate = function(self, card, context)
-        if context.setting_blind and not card.getting_sliced then play_sound(mod_prefix .. "_marbles", nil, 0.1) end
+        if context.setting_blind and not card.getting_sliced then
+            play_sound(mod_prefix .. "_marbles", nil, 0.1)
+        end
     end,
 }

--- a/jokers/misprint.lua
+++ b/jokers/misprint.lua
@@ -1,8 +1,7 @@
 return {
     key = "misprint",
     calculate = function(self, card, context)
-        if
-        context.joker_main then
+        if context.joker_main then
             if pseudorandom(self.key) > 0.5 then
                 return { mult = card.ability.extra.min }
             else

--- a/jokers/mr_bones.lua
+++ b/jokers/mr_bones.lua
@@ -1,7 +1,11 @@
 return {
     key = "mr_bones",
     calculate = function(self, card, context)
-        if context.end_of_round and context.game_over and G.GAME.chips / G.GAME.blind.chips >= 0.25 then
+        if
+            context.end_of_round
+            and context.game_over
+            and G.GAME.chips / G.GAME.blind.chips >= 0.25
+        then
             SMODS.restart_game()
         end
     end,

--- a/jokers/oops.lua
+++ b/jokers/oops.lua
@@ -76,9 +76,11 @@ return {
     remove_from_deck = function(self, card, from_debuff)
         -- set cardareas to 6
         -- joker
-        G.jokers.config.card_limit = card.ability.extra.joker_limit - (6 - G.jokers.config.card_limit)
+        G.jokers.config.card_limit = card.ability.extra.joker_limit
+            - (6 - G.jokers.config.card_limit)
         --consumables
-        G.consumeables.config.card_limit = card.ability.extra.consumables_limit - (6 - G.consumeables.config.card_limit)
+        G.consumeables.config.card_limit = card.ability.extra.consumables_limit
+            - (6 - G.consumeables.config.card_limit)
         -- hand size
         G.hand:change_size(-card.ability.extra.hand_size_offset)
 
@@ -105,7 +107,9 @@ return {
             G.GAME.hands[key].s_mult = card.ability.extra.poker_hands[key].s_mult
             G.GAME.hands[key].s_chips = card.ability.extra.poker_hands[key].s_chips
             -- reset level and recalculates current hand level and chips and mult
-            local new_level = card.ability.extra.poker_hands[key].level + G.GAME.hands[key].level - 6
+            local new_level = card.ability.extra.poker_hands[key].level
+                + G.GAME.hands[key].level
+                - 6
             G.GAME.hands[key].level = 0
             level_up_hand(card, key, true, new_level)
         end

--- a/jokers/raised_fist.lua
+++ b/jokers/raised_fist.lua
@@ -6,7 +6,9 @@ return {
             local temp_ID = math.huge
             local raised_card = nil
             for i = 1, #G.hand.cards do
-                if temp_ID >= G.hand.cards[i].base.id and not SMODS.has_no_rank(G.hand.cards[i]) then
+                if
+                    temp_ID >= G.hand.cards[i].base.id and not SMODS.has_no_rank(G.hand.cards[i])
+                then
                     temp_ID = G.hand.cards[i].base.id
                     raised_card = G.hand.cards[i]
                 end

--- a/jokers/riff_raff.lua
+++ b/jokers/riff_raff.lua
@@ -1,7 +1,7 @@
 SMODS.Joker({
     key = "common",
     config = {
-        extra = 30
+        extra = 30,
     },
     cost = 1,
     atlas = "folly_jokers",
@@ -12,7 +12,7 @@ SMODS.Joker({
     calculate = function(self, card, context)
         if context.joker_main then
             return {
-                chips = card.ability.extra
+                chips = card.ability.extra,
             }
         end
     end,
@@ -25,26 +25,30 @@ return {
     key = "riff_raff",
     name = "fj_riff_raff",
     config = {
-        name = "fj_riff_raff"
+        name = "fj_riff_raff",
     },
     calculate = function(self, card, context)
-        if context.setting_blind
-                and not (context.blueprint_card or card).getting_sliced
-                and #G.jokers.cards + G.GAME.joker_buffer < G.jokers.config.card_limit then
-            local nr_of_jokers = math.min(2,  G.jokers.config.card_limit - (#G.jokers.cards + G.GAME.joker_buffer))
+        if
+            context.setting_blind
+            and not (context.blueprint_card or card).getting_sliced
+            and #G.jokers.cards + G.GAME.joker_buffer < G.jokers.config.card_limit
+        then
+            local nr_of_jokers =
+                math.min(2, G.jokers.config.card_limit - (#G.jokers.cards + G.GAME.joker_buffer))
             G.GAME.joker_buffer = G.GAME.joker_buffer + nr_of_jokers
             G.E_MANAGER:add_event(Event({
                 func = function()
                     for _ = 1, nr_of_jokers do
-                        SMODS.add_card({ key = folly_utils.prefix.joker.."common" })
+                        SMODS.add_card({ key = folly_utils.prefix.joker .. "common" })
                     end
                     G.GAME.joker_buffer = 0
                     return true
-                end}))
+                end,
+            }))
             SMODS.calculate_effect({ message = localize("k_plus_joker"), colour = G.C.BLUE }, card)
         end
     end,
     loc_vars = function(self, info_queue, card)
-        return { vars = { 2 }}
+        return { vars = { 2 } }
     end,
 }

--- a/jokers/rocket.lua
+++ b/jokers/rocket.lua
@@ -4,7 +4,7 @@ local mod_prefix = SMODS.current_mod.prefix
 for i = 1, alien_sound_count do
     SMODS.Sound({
         key = "alien_" .. i,
-        path = "alien_" .. i .. ".ogg"
+        path = "alien_" .. i .. ".ogg",
     })
 end
 
@@ -39,19 +39,23 @@ SMODS.Joker({
                         func = function()
                             play_random_alien(1.25)
                             return true
-                        end
+                        end,
                     }))
-                end
+                end,
             }
         end
     end,
     set_ability = function(self, card, initial, delay_sprites)
-        local chips = folly_utils.pseudorandom_range(card.ability.extra.low, card.ability.extra.high, self.key)
+        local chips = folly_utils.pseudorandom_range(
+            card.ability.extra.low,
+            card.ability.extra.high,
+            self.key
+        )
         card.ability.extra.chips = round_number(chips, 0)
     end,
     loc_vars = function(self, info_queue, card)
         return { vars = { card.ability.extra.chips } }
-    end
+    end,
 })
 
 SMODS.Joker({
@@ -80,19 +84,23 @@ SMODS.Joker({
                         func = function()
                             play_random_alien(1)
                             return true
-                        end
+                        end,
                     }))
-                end
+                end,
             }
         end
     end,
     set_ability = function(self, card, initial, delay_sprites)
-        local mult = folly_utils.pseudorandom_range(card.ability.extra.low, card.ability.extra.high, self.key)
+        local mult = folly_utils.pseudorandom_range(
+            card.ability.extra.low,
+            card.ability.extra.high,
+            self.key
+        )
         card.ability.extra.mult = round_number(mult, 0)
     end,
     loc_vars = function(self, info_queue, card)
         return { vars = { card.ability.extra.mult } }
-    end
+    end,
 })
 
 SMODS.Joker({
@@ -121,19 +129,23 @@ SMODS.Joker({
                         func = function()
                             play_random_alien(0.75)
                             return true
-                        end
+                        end,
                     }))
-                end
+                end,
             }
         end
     end,
     set_ability = function(self, card, initial, delay_sprites)
-        local x_mult = folly_utils.pseudorandom_range(card.ability.extra.low, card.ability.extra.high, self.key)
+        local x_mult = folly_utils.pseudorandom_range(
+            card.ability.extra.low,
+            card.ability.extra.high,
+            self.key
+        )
         card.ability.extra.x_mult = x_mult
     end,
     loc_vars = function(self, info_queue, card)
         return { vars = { card.ability.extra.x_mult } }
-    end
+    end,
 })
 
 SMODS.Joker({
@@ -162,16 +174,25 @@ SMODS.Joker({
                         func = function()
                             play_random_alien(1.5)
                             return true
-                        end
+                        end,
                     }))
-                end
+                end,
             }
         end
 
-        if not context.blueprint and context.using_consumeable and context.consumeable.ability.name == "c_folly_strange_planet" then
-            card.ability.extra.x_mult = card.ability.extra.x_mult + folly_utils.pseudorandom_range(card.ability.extra.low, card.ability.extra.high, self.key)
+        if
+            not context.blueprint
+            and context.using_consumeable
+            and context.consumeable.ability.name == "c_folly_strange_planet"
+        then
+            card.ability.extra.x_mult = card.ability.extra.x_mult
+                + folly_utils.pseudorandom_range(
+                    card.ability.extra.low,
+                    card.ability.extra.high,
+                    self.key
+                )
             return {
-                message = localize('k_folly_glorp')
+                message = localize("k_folly_glorp"),
             }
         end
     end,
@@ -180,10 +201,10 @@ SMODS.Joker({
             vars = {
                 card.ability.extra.low,
                 card.ability.extra.high,
-                card.ability.extra.x_mult
-            }
+                card.ability.extra.x_mult,
+            },
         }
-    end
+    end,
 })
 
 SMODS.Consumable({
@@ -213,10 +234,9 @@ SMODS.Consumable({
     end,
     can_use = function(self, card)
         return #G.jokers.cards < G.jokers.config.card_limit
-    end
+    end,
 })
 
 return {
     key = "rocket",
 }
-

--- a/jokers/satellite.lua
+++ b/jokers/satellite.lua
@@ -38,5 +38,5 @@ return {
                 G.GAME.planet_rate = 0
             end
         end
-    end
+    end,
 }

--- a/jokers/sixth_sense.lua
+++ b/jokers/sixth_sense.lua
@@ -20,35 +20,50 @@ SMODS.Consumable({
     use = function(self, card, area, copier)
         for i, v in pairs(G.hand.highlighted) do
             local percent = 1.15 - (i - 0.999) / (#G.hand.highlighted - 0.998) * 0.3
-            G.E_MANAGER:add_event(Event({ trigger = 'after', delay = 0.15, func = function()
-                v:flip();
-                play_sound('card1', percent);
-                G.hand.highlighted[i]:juice_up(0.3, 0.3);
-                return true
-            end }))
+            G.E_MANAGER:add_event(Event({
+                trigger = "after",
+                delay = 0.15,
+                func = function()
+                    v:flip()
+                    play_sound("card1", percent)
+                    G.hand.highlighted[i]:juice_up(0.3, 0.3)
+                    return true
+                end,
+            }))
         end
         for i, v in pairs(G.hand.highlighted) do
-            G.E_MANAGER:add_event(Event({ trigger = 'after', delay = 0.5, func = function()
-                v:set_edition(card.ability.extra.edition)
-                v:set_seal(card.ability.extra.seal)
-                v:set_ability(card.ability.extra.enhancement)
-                SMODS.change_base(v, card.ability.extra.suit, '6')
-                return true
-            end }))
+            G.E_MANAGER:add_event(Event({
+                trigger = "after",
+                delay = 0.5,
+                func = function()
+                    v:set_edition(card.ability.extra.edition)
+                    v:set_seal(card.ability.extra.seal)
+                    v:set_ability(card.ability.extra.enhancement)
+                    SMODS.change_base(v, card.ability.extra.suit, "6")
+                    return true
+                end,
+            }))
         end
         for i, v in pairs(G.hand.highlighted) do
             local percent = 0.85 + (i - 0.999) / (#G.hand.highlighted - 0.998) * 0.3
-            G.E_MANAGER:add_event(Event({ trigger = 'after', delay = 0.15, func = function()
-                v:flip();
-                play_sound('tarot2', percent, 0.6);
-                G.hand.highlighted[i]:juice_up(0.3, 0.3);
-                return true
-            end }))
+            G.E_MANAGER:add_event(Event({
+                trigger = "after",
+                delay = 0.15,
+                func = function()
+                    v:flip()
+                    play_sound("tarot2", percent, 0.6)
+                    G.hand.highlighted[i]:juice_up(0.3, 0.3)
+                    return true
+                end,
+            }))
         end
-        G.E_MANAGER:add_event(Event({ trigger = 'after', func = function()
-            G.hand:unhighlight_all()
-            return true
-        end }))
+        G.E_MANAGER:add_event(Event({
+            trigger = "after",
+            func = function()
+                G.hand:unhighlight_all()
+                return true
+            end,
+        }))
     end,
     in_pool = function(self, args)
         return false
@@ -66,9 +81,8 @@ SMODS.Consumable({
         if not from_debuff then
             card:set_sprites(G.P_CENTERS[card.ability.extra.enhancement])
         end
-    end
+    end,
 })
-
 
 return {
     key = "sixth_sense",
@@ -76,35 +90,49 @@ return {
         extra = 1,
     },
     calculate = function(self, card, context)
-        if context.destroying_card and #context.full_hand == 1 and context.full_hand[1]:get_id() == 6 and G.GAME.current_round.hands_played == 0 then
-            if #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit then
+        if
+            context.destroying_card
+            and #context.full_hand == 1
+            and context.full_hand[1]:get_id() == 6
+            and G.GAME.current_round.hands_played == 0
+        then
+            if
+                #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit
+            then
                 G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
                 G.E_MANAGER:add_event(Event({
-                    trigger = 'before',
+                    trigger = "before",
                     func = function()
                         local area = G.consumeables
                         local created_card = SMODS.create_card({
-                            key = 'c_folly_six'
+                            key = "c_folly_six",
                         })
                         local edition_rate = 2
-                        local edition = poll_edition('standard_edition' .. G.GAME.round_resets.ante, edition_rate, true)
-                        local suit = pseudorandom_element(SMODS.Suits, pseudoseed('suit'))
+                        local edition = poll_edition(
+                            "standard_edition" .. G.GAME.round_resets.ante,
+                            edition_rate,
+                            true
+                        )
+                        local suit = pseudorandom_element(SMODS.Suits, pseudoseed("suit"))
                         created_card.ability.extra.suit = suit.key
-                        SMODS.change_base(created_card, suit.key, '6')
+                        SMODS.change_base(created_card, suit.key, "6")
                         created_card:set_edition(edition, true, true)
                         created_card.ability.extra.edition = edition
                         local seal = SMODS.poll_seal({ mod = 10 })
                         created_card:set_seal(seal)
                         created_card.ability.extra.seal = seal
-                        local enhancement = SMODS.poll_enhancement({ mod = 6, options = {
-                            "m_bonus",
-                            "m_mult",
-                            "m_wild",
-                            "m_glass",
-                            "m_steel",
-                            "m_gold",
-                            "m_lucky",
-                        } })
+                        local enhancement = SMODS.poll_enhancement({
+                            mod = 6,
+                            options = {
+                                "m_bonus",
+                                "m_mult",
+                                "m_wild",
+                                "m_glass",
+                                "m_steel",
+                                "m_gold",
+                                "m_lucky",
+                            },
+                        })
                         created_card.ability.extra.enhancement = enhancement
                         created_card:set_sprites(G.P_CENTERS[enhancement])
                         area:emplace(created_card)
@@ -116,5 +144,5 @@ return {
             end
             return true
         end
-    end
+    end,
 }

--- a/jokers/space.lua
+++ b/jokers/space.lua
@@ -56,15 +56,21 @@ return {
             if sound == space_sounds.dollar then
                 retval.level_up = false
                 -- use func instead of retval.dollar since it has better timing
-                retval.func = function() ease_dollars(1) end
+                retval.func = function()
+                    ease_dollars(1)
+                end
             elseif sound == space_sounds.lmao then
                 retval.level_up = false
-                retval.func = function() level_up_hand(card, context.scoring_name, nil, -1) end
+                retval.func = function()
+                    level_up_hand(card, context.scoring_name, nil, -1)
+                end
             elseif sound == space_sounds.big_american_tts then
                 -- level up twice
                 -- "Holy cow, two big ones" - Northernlion
                 retval.level_up = false
-                retval.func = function() level_up_hand(card, context.scoring_name, nil, 2) end
+                retval.func = function()
+                    level_up_hand(card, context.scoring_name, nil, 2)
+                end
             elseif sound == space_sounds.mark then
                 for _, playing_card in pairs(context.scoring_hand) do
                     playing_card:add_sticker("folly_mark_sticker", true)
@@ -72,10 +78,14 @@ return {
             elseif sound == space_sounds.question_mark then
                 -- shuffle jokers cards
                 -- for funnsies
-                retval.func = function() folly_utils.shuffle_cardarea() end
+                retval.func = function()
+                    folly_utils.shuffle_cardarea()
+                end
             elseif sound == space_sounds.aeiou then
                 -- shuffle played cards
-                retval.func = function() folly_utils.shuffle_cardarea(G.play) end
+                retval.func = function()
+                    folly_utils.shuffle_cardarea(G.play)
+                end
             end
             return retval
         end

--- a/jokers/trading.lua
+++ b/jokers/trading.lua
@@ -21,7 +21,7 @@ return {
         },
         name = "fj_trading",
     },
-    
+
     calculate = function(self, card, context)
         if context.first_hand_drawn and not context.blueprint then
             local eval = function()
@@ -30,21 +30,36 @@ return {
             juice_card_until(card, eval, true)
         end
 
-        if context.discard
-                and not context.blueprint
-                and G.GAME.current_round.discards_used <= 0 and #context.full_hand <= card.ability.extra.discards then
+        if
+            context.discard
+            and not context.blueprint
+            and G.GAME.current_round.discards_used <= 0
+            and #context.full_hand <= card.ability.extra.discards
+        then
             local playing_card = {
                 attack = context.other_card.base.nominal,
                 health = context.other_card.base.id - 1,
             }
             card.ability.extra.health = card.ability.extra.health - playing_card.attack
             if card.ability.extra.health <= 0 then
-                card:shatter();
-                SMODS.calculate_effect({ message = card.ability.extra.attack .. localize("k_folly_tc_dead"), colour = G.C.BLUE }, context.other_card)
+                card:shatter()
+                SMODS.calculate_effect(
+                    {
+                        message = card.ability.extra.attack .. localize("k_folly_tc_dead"),
+                        colour = G.C.BLUE,
+                    },
+                    context.other_card
+                )
             end
 
             if card.ability.extra.attack < playing_card.health then
-                SMODS.calculate_effect({ message = card.ability.extra.attack .. localize("k_folly_tc_damage"), colour = G.C.BLUE }, context.other_card)
+                SMODS.calculate_effect(
+                    {
+                        message = card.ability.extra.attack .. localize("k_folly_tc_damage"),
+                        colour = G.C.BLUE,
+                    },
+                    context.other_card
+                )
                 SMODS.modify_rank(context.other_card, -card.ability.extra.attack)
                 self.update_atlas_stats(card)
                 return
@@ -53,7 +68,7 @@ return {
                 self.add_level(card, self.level_stat_sheet)
                 self.update_atlas_stats(card)
                 return {
-                    message = localize('$') .. card.ability.extra.money,
+                    message = localize("$") .. card.ability.extra.money,
                     colour = G.C.MONEY,
                     delay = 0.45,
                     remove = true,
@@ -72,14 +87,17 @@ return {
     end,
 
     loc_vars = function(self, info_queue, card)
-        local key = self.key.."_alt"
-        if card.ability.extra.discards > 1 then key = key.."_multiple" end
-        return { 
+        local key = self.key .. "_alt"
+        if card.ability.extra.discards > 1 then
+            key = key .. "_multiple"
+        end
+        return {
             key = key,
             vars = {
-            card.ability.extra.discards,
-            card.ability.extra.money,
-        }, }
+                card.ability.extra.discards,
+                card.ability.extra.money,
+            },
+        }
     end,
 
     level_stat_sheet = {
@@ -117,9 +135,12 @@ return {
         card.ability.extra.max_health = level_stats.max_health
         card.ability.extra.money = level_stats.money
     end,
-    
+
     update_atlas_stats = function(card)
-        card.children.center:set_sprite_pos({ x = card.ability.extra.attack - 4, y = card.ability.extra.health - 1 })
+        card.children.center:set_sprite_pos({
+            x = card.ability.extra.attack - 4,
+            y = card.ability.extra.health - 1,
+        })
     end,
     set_sprites = function(self, card, front)
         if card.ability then

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -27,7 +27,7 @@ return {
             k_folly_moonbase_alpha_uuuuuuueeeeeeeeeeuuuuuuu = "uuuueeeeuuuu",
             k_folly_tc_damage = "Defeat!",
             k_folly_glorp = "Glorp",
-            
+
             --Object Types
             k_funny = "Funny :)",
             b_funny_cards = "Funny :)",
@@ -123,20 +123,20 @@ return {
             j_folly_alien = {
                 name = "Alien",
                 text = {
-                    "{C:chips}+#1#{} chips"
-                }
+                    "{C:chips}+#1#{} chips",
+                },
             },
             j_folly_super_alien = {
                 name = "Super Alien",
                 text = {
-                    "{C:mult}+#1#{} Mult"
-                }
+                    "{C:mult}+#1#{} Mult",
+                },
             },
             j_folly_giga_alien = {
                 name = "Giga Alien",
                 text = {
-                    "{X:mult,C:white}X#1#{} Mult"
-                }
+                    "{X:mult,C:white}X#1#{} Mult",
+                },
             },
             j_folly_glorp_alien = {
                 name = "Glorp",
@@ -163,9 +163,9 @@ return {
                     "{C:mult}+4{} Mult",
                     "Counts as {C:attention}best",
                     "suit or rank",
-                    "in {C:attention}poker hands"
+                    "in {C:attention}poker hands",
                 },
-            }
+            },
         },
         funny = {
             c_folly_six = {
@@ -193,7 +193,7 @@ return {
                 text = {
                     "Beware of what",
                     "lies beyond",
-                    "the stars"
+                    "the stars",
                 },
             },
         },

--- a/main.lua
+++ b/main.lua
@@ -36,12 +36,16 @@ local function new_troll_joker(joker)
         loc_txt = G.localization.descriptions.Joker[original_joker.key], -- use original jokers description
     }, original_joker)
     troll_joker.mod = nil --crashes if I don't fuck this
-    if joker.loc_vars then troll_joker.generate_ui = nil end
+    if joker.loc_vars then
+        troll_joker.generate_ui = nil
+    end
     SMODS.Joker(SMODS.merge_defaults(joker, troll_joker))
 end
 
 -- load all jokers in joker dir
 for _, file in ipairs(NFS.getDirectoryItems(SMODS.current_mod.path .. "jokers")) do
     local joker = assert(SMODS.load_file("jokers/" .. file))()
-    if type(joker) == "table" then new_troll_joker(joker) end
+    if type(joker) == "table" then
+        new_troll_joker(joker)
+    end
 end

--- a/override.lua
+++ b/override.lua
@@ -68,35 +68,46 @@ end
 function get_straight(hand, min_length, skip, wrap)
     local jimbos = {}
     for i, v in pairs(hand) do
-        if SMODS.has_enhancement(v, 'm_folly_jimbo') then
+        if SMODS.has_enhancement(v, "m_folly_jimbo") then
             table.insert(jimbos, v)
         end
     end
     if #jimbos >= min_length then
-        return {straight = jimbos}
+        return { straight = jimbos }
     end
     min_length = min_length or 5
-    if min_length < 2 then min_length = 2 end
-    if #hand < min_length then return {} end
+    if min_length < 2 then
+        min_length = 2
+    end
+    if #hand < min_length then
+        return {}
+    end
     local ranks = {}
-    for k,_ in pairs(SMODS.Ranks) do ranks[k] = {} end
-    for _,card in ipairs(hand) do
+    for k, _ in pairs(SMODS.Ranks) do
+        ranks[k] = {}
+    end
+    for _, card in ipairs(hand) do
         local id = card:get_id()
         if id > 0 then
-            for k,v in pairs(SMODS.Ranks) do
-                if v.id == id then table.insert(ranks[k], card); break end
+            for k, v in pairs(SMODS.Ranks) do
+                if v.id == id then
+                    table.insert(ranks[k], card)
+                    break
+                end
             end
         end
     end
     local function next_ranks(key, start)
         local rank = SMODS.Ranks[key]
         local ret = {}
-        if not start and not wrap and rank.straight_edge then return ret end
-        for _,v in ipairs(rank.next) do
-            ret[#ret+1] = v
+        if not start and not wrap and rank.straight_edge then
+            return ret
+        end
+        for _, v in ipairs(rank.next) do
+            ret[#ret + 1] = v
             if skip and (wrap or not SMODS.Ranks[v].straight_edge) then
-                for _,w in ipairs(SMODS.Ranks[v].next) do
-                    ret[#ret+1] = w
+                for _, w in ipairs(SMODS.Ranks[v].next) do
+                    ret[#ret + 1] = w
                 end
             end
         end
@@ -104,60 +115,62 @@ function get_straight(hand, min_length, skip, wrap)
     end
     local tuples = {}
     local ret = {}
-    for _,k in ipairs(SMODS.Rank.obj_buffer) do
+    for _, k in ipairs(SMODS.Rank.obj_buffer) do
         if next(ranks[k]) then
-            tuples[#tuples+1] = {key = {k}, jimbos = #jimbos}
+            tuples[#tuples + 1] = { key = { k }, jimbos = #jimbos }
         end
     end
-    for i = 2, #hand+1 do
+    for i = 2, #hand + 1 do
         local new_tuples = {}
         for _, tuple in ipairs(tuples) do
             local any_tuple
-            if i ~= #hand+1 then
-                for _,l in ipairs(next_ranks(tuple.key[i-1], i == 2)) do
+            if i ~= #hand + 1 then
+                for _, l in ipairs(next_ranks(tuple.key[i - 1], i == 2)) do
                     if next(ranks[l]) then
-                        local new_tuple = {key = {}, jimbo = 0}
-                        for _,v in ipairs(tuple.key) do
-                            new_tuple.key[#new_tuple.key+1] = v
+                        local new_tuple = { key = {}, jimbo = 0 }
+                        for _, v in ipairs(tuple.key) do
+                            new_tuple.key[#new_tuple.key + 1] = v
                         end
-                        new_tuple.key[#new_tuple.key+1] = l
+                        new_tuple.key[#new_tuple.key + 1] = l
                         new_tuple.jimbos = tuple.jimbos
-                        new_tuples[#new_tuples+1] = new_tuple
+                        new_tuples[#new_tuples + 1] = new_tuple
                         any_tuple = true
                     end
                 end
                 if not any_tuple and tuple.jimbos > 0 then -- check if the we have a "jimbo token" in the tuple
                     local next = 0
-                    local new_tuple = {key = {}, jimbo = 0}
-                    for _,v in ipairs(tuple.key) do
-                        new_tuple.key[#new_tuple.key+1] = v
+                    local new_tuple = { key = {}, jimbo = 0 }
+                    for _, v in ipairs(tuple.key) do
+                        new_tuple.key[#new_tuple.key + 1] = v
                         if SMODS.Ranks[v].straight_edge then -- back track by 4 if we don't have a "next" value
                             next = folly_utils.get_previous_rank(v, 4)
                         else
                             next = next_ranks(v)[1]
                         end
                     end
-                    new_tuple.key[#new_tuple.key+1] = next
+                    new_tuple.key[#new_tuple.key + 1] = next
                     new_tuple.jimbos = tuple.jimbos - 1
-                    new_tuples[#new_tuples+1] = new_tuple
+                    new_tuples[#new_tuples + 1] = new_tuple
                     any_tuple = true
                 end
             end
             if i > min_length and not any_tuple then
                 local straight = {}
-                for _,v in ipairs(tuple.key) do
-                    for _,card in ipairs(ranks[v]) do
-                        straight[#straight+1] = card
+                for _, v in ipairs(tuple.key) do
+                    for _, card in ipairs(ranks[v]) do
+                        straight[#straight + 1] = card
                     end
                 end
                 for j = 1, #jimbos do -- fill the empty slots with the jimbos we added
-                    straight[#straight+1] = jimbos[j]
+                    straight[#straight + 1] = jimbos[j]
                 end
-                ret[#ret+1] = straight
+                ret[#ret + 1] = straight
             end
         end
         tuples = new_tuples
     end
-    table.sort(ret, function(a,b) return #a > #b end)
+    table.sort(ret, function(a, b)
+        return #a > #b
+    end)
     return ret
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1149 @@
+{
+  "name": "troll-mod",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@johnnymorganz/stylua-bin": "^2.1.0"
+      }
+    },
+    "node_modules/@johnnymorganz/stylua-bin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@johnnymorganz/stylua-bin/-/stylua-bin-2.1.0.tgz",
+      "integrity": "sha512-ztGW8b7uoPEzqaUftCkY27tcLUmFDCRyGIJrf7WKyAd0hpNbF+Q43rmGM71RYD6oQ9JYGUQXXC+r/WZqeTd/Ew==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axios": "^1.6.0",
+        "node-fetch": "^3.2.10",
+        "proxy-agent": "^6.4.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      },
+      "bin": {
+        "stylua": "run.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "scripts": {
+    "stylua": "stylua",
+    "format-check": "stylua --check .",
+    "format-all": "stylua ."
+  },
+  "devDependencies": {
+    "@johnnymorganz/stylua-bin": "^2.1.0"
+  }
+}

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,3 +1,13 @@
+syntax = "LuaJIT"
+column_width = 100
+line_endings = "Unix"
 indent_type = "Spaces"
+indent_width = 4
+quote_style = "AutoPreferDouble"
 call_parentheses = "Always"
-collapse_simple_statement = "Always"
+# might consider "ConditionalOnly"
+collapse_simple_statement = "Never"
+space_after_function_names = "Never"
+
+[sort_requires]
+enabled = false

--- a/utils.lua
+++ b/utils.lua
@@ -29,30 +29,30 @@ folly_utils = {
     end,
 
     prefix = {
-        joker = "j_" .. SMODS.current_mod.prefix .. "_"
+        joker = "j_" .. SMODS.current_mod.prefix .. "_",
     },
-    
+
     log = {
         Trace = function(message)
-            sendTraceMessage(message, display_name);
+            sendTraceMessage(message, display_name)
         end,
         Debug = function(message)
-            sendDebugMessage(message, display_name);
+            sendDebugMessage(message, display_name)
         end,
         Info = function(message)
-            sendInfoMessage(message,display_name);
+            sendInfoMessage(message, display_name)
         end,
         Warn = function(message)
-            sendWarnMessage(message,display_name);
+            sendWarnMessage(message, display_name)
         end,
         Error = function(message)
-            sendErrorMessage(message, display_name);
+            sendErrorMessage(message, display_name)
         end,
         Fatal = function(message)
-            sendFatalMessage(message, display_name);
+            sendFatalMessage(message, display_name)
         end,
     },
-    
+
     lerp = function(a, b, t)
         return a + (b - a) * t
     end,
@@ -75,7 +75,7 @@ folly_utils = {
         end
         delay(0.35) --extra delay when done
     end,
-    
+
     get_previous_rank = function(key, offset)
         offset = offset or 1
         if offset <= 0 then


### PR DESCRIPTION
install stylua with `npm i`
by using npm we make sure to use the same version of stylua and makes it part of the codebase

I added some npm scripts
`npm run format-all` format all lua files
`npm run format-check` check if files are formatted
`npm run stylua` run stylua directly, needs arguments to do anything. put `--` before any arguments to stylua like the example below

This takes a file from stdin and formats it. replace {buffer_path} with what your editor uses.
`npm run stylua -- --respect-ingores --stdin-filepath {buffer_path} -` 

You can also run it with npx directly and don't need `--` to seperate the arguments. this is what i use in my zed config right now.
`npx @johnnymorganz/stylua-bin --respect-ingores --stdin-filepath {buffer_path} -`

check `stylua.toml` for styling settings and comment if there's anything you think we should change