### PR TITLE
chore: ignore .lovelyignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ﻿.idea
 Folder.DotSettings.user
 node_modules
+.lovelyignore


### PR DESCRIPTION
To disable a mod you need to add a `.lovelyignore` file in the root of the mod. smods does this for you if you disable a mod in game. We never want to commit that file so i think its good to ignore it so it never gets commited