### PR TITLE
fix: alien didn't use mod prefix

### DIFF
--- a/jokers/rocket.lua
+++ b/jokers/rocket.lua
@@ -9,7 +9,7 @@ end
 
 local function play_random_alien(pitch)
     local sound = math.random(alien_sound_count)
-    play_sound(mod_prefix .. "_alien_" .. sound, pitch)
+    play_sound(folly_utils.prefix.mod .. "_alien_" .. sound, pitch)
 end
 
 SMODS.Joker({


### PR DESCRIPTION
for some reason when main was merged into #38 we reverted back to using `mod_prefix` instead of `folly_utils.prefix.mod` from #41

closes #48 